### PR TITLE
Fix embed tag parseFile reference

### DIFF
--- a/index.js
+++ b/index.js
@@ -523,6 +523,7 @@ exports.Swig = function (opts) {
    * @return {object}         Renderable function and tokens object.
    */
   this.precompile = function (source, options) {
+    options = utils.extend({ swig: self }, options)
     var tokens = self.parse(source, options)
     var parents = getParents(tokens, options)
     var tpl

--- a/tags/embed.js
+++ b/tags/embed.js
@@ -10,7 +10,8 @@ exports.compile = function (compiler, args, content, parents, opts) {
   var file = args.shift()
   var parentFile = (args.pop() || '').replace(/\\/g, '\\')
   var filepath = file.replace(/^['"]|['"]$/g, '')
-  var parsed = _swig.parseFile(filepath, { resolveFrom: parentFile })
+  var swig = (opts && opts.swig) || _swig
+  var parsed = swig.parseFile(filepath, { resolveFrom: parentFile })
   return compiler(parsed.tokens, parents, opts)
 }
 


### PR DESCRIPTION
## Summary
- allow `embed` tag to access swig instance during compile
- pass swig instance via options when precompiling templates

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6884ff781cbc83339c4a8dc63f1a1675